### PR TITLE
pre-compile regex

### DIFF
--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -1,4 +1,5 @@
 const Util = require("./util");
+const regexOneOrMoreEngLetters = /[a-zA-Z]+/;
 
 let RiTa;
 
@@ -55,7 +56,6 @@ class Analyzer {
       }
 
       // if no phones yet, try the lts-engine
-      const regexOneOrMoreEngLetters = /[a-zA-Z]+/
       if (!rawPhones) {
         let ltsPhones = RiTa.lts && RiTa.lts.computePhones(word);
         if (ltsPhones && ltsPhones.length > 0) {

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -40,7 +40,7 @@ class Analyzer {
     let silentLts = opts && opts.silent;
 
     // check the cache first
-    let result = RiTa.CACHING && this.cache[word]; 
+    let result = RiTa.CACHING && this.cache[word];
     if (typeof result === 'undefined') {
 
       let useRaw = false, slash = '/', delim = '-';
@@ -55,11 +55,12 @@ class Analyzer {
       }
 
       // if no phones yet, try the lts-engine
+      const regexOneOrMoreEngLetters = /[a-zA-Z]+/
       if (!rawPhones) {
         let ltsPhones = RiTa.lts && RiTa.lts.computePhones(word);
         if (ltsPhones && ltsPhones.length > 0) {
           if (!RiTa.SILENT && !RiTa.SILENCE_LTS && !silentLts
-            && RiTa.hasLexicon() && word.match(/[a-zA-Z]+/)) {
+            && RiTa.hasLexicon() && word.match(regexOneOrMoreEngLetters)) {
             console.log("[RiTa] Used LTS-rules for '" + word + "'");
           }
           rawPhones = Util.syllablesFromPhones(ltsPhones);

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -1,4 +1,8 @@
 const deepMerge = require('deepmerge');
+const regexOneForaddRule = /\|/;
+// check if there is '|'
+const regexTwoForaddRule = /^\(.*\)$/;
+// check if there is "()"
 
 // TODO:
 //    add fromJSON toJSON
@@ -40,12 +44,7 @@ class Grammar {
     if (!name || !name.length) throw Error('expected [string] name');
     if (name.startsWith('$')) name = name.substring(1);
     if (Array.isArray(rule)) rule = joinChoice(rule);
-
-    const regexOne = /\|/;
-    // check if there is '|'
-    const regexTwo = /^\(.*\)$/;
-    // check if there is "()"
-    if (regexOne.test(rule) && !(regexTwo.test(rule))) {
+    if (regexOneForaddRule.test(rule) && !(regexTwoForaddRule.test(rule))) {
       rule = '(' + rule + ')';
     }
     this.rules[name] = rule;

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -16,7 +16,7 @@ class Grammar {
   static fromJSON(json, context) {
     return new Grammar().setRules(json);
   }
-  
+
   toJSON() {
     return stringify(Object.keys(this).reduce(
       (acc, k) => Object.assign(acc, { [k]: this[k] }), {}));
@@ -41,8 +41,11 @@ class Grammar {
     if (name.startsWith('$')) name = name.substring(1);
     if (Array.isArray(rule)) rule = joinChoice(rule);
 
-    // TODO: better regex here: if '|' happens before '('
-    if (/\|/.test(rule) && !(/^\(.*\)$/.test(rule))) {
+    const regexOne = /\|/;
+    // check if there is '|'
+    const regexTwo = /^\(.*\)$/;
+    // check if there is "()"
+    if (regexOne.test(rule) && !(regexTwo.test(rule))) {
       rule = '(' + rule + ')';
     }
     this.rules[name] = rule;

--- a/src/lexicon.js
+++ b/src/lexicon.js
@@ -1,4 +1,5 @@
 const Util = require("./util");
+const regexCompiledFor_isConsonant = /^[a-z\u00C0-\u00ff]+$/;
 
 let RiTa;
 
@@ -377,9 +378,8 @@ class Lexicon {
   }
 
   _isConsonant(p) {
-    const regexCompiled = /^[a-z\u00C0-\u00ff]+$/;
     return (typeof p === S && p.length === 1 && // precompile
-      RiTa.VOWELS.indexOf(p) < 0 && regexCompiled.test(p));
+      RiTa.VOWELS.indexOf(p) < 0 && regexCompiledFor_isConsonant.test(p));
   }
 
   _firstPhone(rawPhones) {

--- a/src/lexicon.js
+++ b/src/lexicon.js
@@ -44,7 +44,7 @@ class Lexicon {
     opts.silent = true;
     for (let i = 0; i < words.length; i++) {
       let word = words[i];
-      // check word length and syllables 
+      // check word length and syllables
       if (word === theWord || !this.checkCriteria(word, dict[word], opts)) {
         continue;
       }
@@ -74,7 +74,7 @@ class Lexicon {
     let result = [];
     for (let i = 0; i < words.length; i++) {
       let word = words[i];
-      // check word length and syllables 
+      // check word length and syllables
       if (word === theWord || !this.checkCriteria(word, dict[word], opts)) {
         continue;
       }
@@ -146,7 +146,7 @@ class Lexicon {
     }
 
     this.parseArgs(opts);
-    
+
     opts._analyzer = RiTa._analyzer();
     let _silent = opts.silent;
     opts.silent = true;
@@ -210,7 +210,7 @@ class Lexicon {
     this.parseArgs(opts);
 
     const dict = this._dict(true);
-    const sound = opts.type === 'sound'; // default: letter 
+    const sound = opts.type === 'sound'; // default: letter
     const words = Object.keys(dict);
     const input = theWord.toLowerCase();
     const variations = [input, input + 's', input + 'es'];
@@ -269,7 +269,7 @@ class Lexicon {
     if (result !== word && opts.numSyllables) {
       let syls = analyzer.analyzeWord(result, SILENT).syllables;
       let num = syls.split(RiTa.SYLLABLE_BOUNDARY).length;
-      
+
       // reject if syllable count has changed
       if (num !== opts.numSyllables) return;
     }
@@ -311,7 +311,7 @@ class Lexicon {
       else if (tpos === "r") tpos = "rb";
       else if (tpos === "a") tpos = "jj";
     }
-    
+
     opts.targetPos = tpos;
   }
 
@@ -377,8 +377,9 @@ class Lexicon {
   }
 
   _isConsonant(p) {
+    const regexCompiled = /^[a-z\u00C0-\u00ff]+$/;
     return (typeof p === S && p.length === 1 && // precompile
-      RiTa.VOWELS.indexOf(p) < 0 && /^[a-z\u00C0-\u00ff]+$/.test(p));
+      RiTa.VOWELS.indexOf(p) < 0 && regexCompiled.test(p));
   }
 
   _firstPhone(rawPhones) {
@@ -408,7 +409,7 @@ class Lexicon {
       }
     }
   }
-  
+
   _lastStressedVowelPhonemeToEnd(word) {
     if (word && word.length) {
       let raw = this._lastStressedPhoneToEnd(word);

--- a/src/markov.js
+++ b/src/markov.js
@@ -9,7 +9,7 @@ class Markov {
     // options (TODO: clarify/document options)
     this.trace = opts.trace;
     this.mlm = opts.maxLengthMatch;
-    this.logDuplicates = opts.logDuplicates; 
+    this.logDuplicates = opts.logDuplicates;
     this.maxAttempts = opts.maxAttempts || 99;
     this.disableInputChecks = opts.disableInputChecks;
     this.tokenize = opts.tokenize || _RiTa().tokenize;
@@ -106,8 +106,9 @@ class Markov {
 
             let sent = this._flatten(tokens);
             if (!allowDuplicates && result.includes(sent) && fail('is dup')) break;
-            this.trace && console.log('-- GOOD', sent.replace(/ +/g, ' '));
-            result.push(sent.replace(/ +/g, ' '));
+            const regexCompiled = / +/g;
+            this.trace && console.log('-- GOOD', sent.replace(regexCompiled, ' '));
+            result.push(sent.replace(regexCompiled, ' '));
             break;
           }
           if (fail('too short')) break;

--- a/src/markov.js
+++ b/src/markov.js
@@ -1,4 +1,5 @@
 const { parse, stringify } = require('flatted/cjs');
+const regexCompiled = / +/g;
 
 class Markov {
 
@@ -106,7 +107,6 @@ class Markov {
 
             let sent = this._flatten(tokens);
             if (!allowDuplicates && result.includes(sent) && fail('is dup')) break;
-            const regexCompiled = / +/g;
             this.trace && console.log('-- GOOD', sent.replace(regexCompiled, ' '));
             result.push(sent.replace(regexCompiled, ' '));
             break;

--- a/src/riscript.js
+++ b/src/riscript.js
@@ -4,6 +4,10 @@ const Visitor = require('./visitor');
 const Lexer = require('../grammar/antlr/RiScriptLexer');
 const Parser = require('../grammar/antlr/RiScriptParser');
 const { LexerErrors, ParserErrors } = require('./errors');
+const regexCompiledForpreParse0 = /^[${]/;
+const regexCompiledForpreParse1 = /[()$|{}]/;
+const regexCompiledForresolveEntities = /[\t\v\f\u00a0\u2000-\u200b\u2028-\u2029\u3000]+/g;
+const regexCompiledForisParseable = /[aeiou]/;
 
 const Parseable = /([()]|\$[A-Za-z_0-9][A-Za-z_0-9-]*)/;
 
@@ -135,18 +139,16 @@ class RiScript {
   preParse(input, opts = {}) {
     let parse = input, pre = '', post = '';
     //console.log('preParse', parse);
-    const regexCompiled = /^[${]/;
-    if (!opts.skipPreParse && !regexCompiled.test(parse)) {
-      const re = /[()$|{}]/;
+    if (!opts.skipPreParse && !regexCompiledForpreParse0.test(parse)) {
       const words = input.split(/ +/);
       let preIdx = 0, postIdx = words.length - 1;
       while (preIdx < words.length) {
-        if (re.test(words[preIdx])) break;
+        if (regexCompiledForpreParse1.test(words[preIdx])) break;
         preIdx++;
       }
       if (preIdx < words.length) {
         while (postIdx >= 0) {
-          if (re.test(words[postIdx])) break;
+          if (regexCompiledForpreParse1.test(words[postIdx])) break;
           postIdx--;
         }
       }
@@ -180,9 +182,8 @@ class RiScript {
   } */
 
   resolveEntities(result) { // &#10; for line break DOC:
-    const re = /[\t\v\f\u00a0\u2000-\u200b\u2028-\u2029\u3000]+/g;
     return decode(result.replace(/ +/g, ' '))
-      .replace(re, ' ');
+      .replace(regexCompiledForresolveEntities, ' ');
   }
 
   isParseable(s) {
@@ -196,9 +197,8 @@ class RiScript {
 
   static articlize(s) {
     let phones = RiTa().phones(s, { silent: true });
-    const re = /[aeiou]/;
     return (phones && phones.length
-      && re.test(phones[0]) ? 'an ' : 'a ') + s;
+      && regexCompiledForisParseable.test(phones[0]) ? 'an ' : 'a ') + s;
   }
 
   // a no-op transform for sequences

--- a/src/riscript.js
+++ b/src/riscript.js
@@ -8,6 +8,7 @@ const regexCompiledForpreParse0 = /^[${]/;
 const regexCompiledForpreParse1 = /[()$|{}]/;
 const regexCompiledForresolveEntities = /[\t\v\f\u00a0\u2000-\u200b\u2028-\u2029\u3000]+/g;
 const regexCompiledForisParseable = /[aeiou]/;
+const regexCompiledForevaluate = /\$[A-Za-z_]/;
 
 const Parseable = /([()]|\$[A-Za-z_0-9][A-Za-z_0-9-]*)/;
 
@@ -49,7 +50,7 @@ class RiScript {
           + input + '"\nafter ' + RiScript.MAX_TRIES + ' tries. An infinite loop?');
       }
     }
-    if (!opts.silent && !RiScript.parent.SILENT && /\$[A-Za-z_]/.test(expr)) {
+    if (!opts.silent && !RiScript.parent.SILENT && regexCompiledForevaluate.test(expr)) {
       console.warn('[WARN] Unresolved symbol(s) in "' + expr + '"');
     }
     return rs.popTransforms(ctx).resolveEntities(expr);

--- a/src/riscript.js
+++ b/src/riscript.js
@@ -135,7 +135,8 @@ class RiScript {
   preParse(input, opts = {}) {
     let parse = input, pre = '', post = '';
     //console.log('preParse', parse);
-    if (!opts.skipPreParse && !/^[${]/.test(parse)) {
+    const regexCompiled = /^[${]/;
+    if (!opts.skipPreParse && !regexCompiled.test(parse)) {
       const re = /[()$|{}]/;
       const words = input.split(/ +/);
       let preIdx = 0, postIdx = words.length - 1;
@@ -171,7 +172,7 @@ class RiScript {
         .replace(/\\n/, '')
         .replace(/\n/, ' ') : '';
   }
-/* 
+/*
   createVisitor(context, opts) {
     if (!this.visitor) this.visitor = new Visitor(this);
     ;
@@ -179,8 +180,9 @@ class RiScript {
   } */
 
   resolveEntities(result) { // &#10; for line break DOC:
+    const re = /[\t\v\f\u00a0\u2000-\u200b\u2028-\u2029\u3000]+/g;
     return decode(result.replace(/ +/g, ' '))
-      .replace(/[\t\v\f\u00a0\u2000-\u200b\u2028-\u2029\u3000]+/g, ' ');
+      .replace(re, ' ');
   }
 
   isParseable(s) {
@@ -194,8 +196,9 @@ class RiScript {
 
   static articlize(s) {
     let phones = RiTa().phones(s, { silent: true });
+    const re = /[aeiou]/;
     return (phones && phones.length
-      && /[aeiou]/.test(phones[0]) ? 'an ' : 'a ') + s;
+      && re.test(phones[0]) ? 'an ' : 'a ') + s;
   }
 
   // a no-op transform for sequences
@@ -203,7 +206,7 @@ class RiScript {
     return s;
   }
 
-  /* 
+  /*
     static addTransform(name, func) { // DOC: object case
       if (typeof name === 'string') {
         return RiScript.transforms[name] = func;
@@ -268,8 +271,8 @@ function pluralize(s) {
 RiScript.MAX_TRIES = 99;
 
 RiScript.transforms = {
-  capitalize, quotify, pluralize, 
-  qq: quotify, uc: toUpper, ucf: capitalize, 
+  capitalize, quotify, pluralize,
+  qq: quotify, uc: toUpper, ucf: capitalize,
   articlize: RiScript.articlize,
   seq: RiScript.identity,
   rseq: RiScript.identity,

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1,4 +1,10 @@
 const Util = require("./util");
+const regexCompiledForsentences = /(\r?\n)+/g;
+//below is regexes for untokenize()
+const punct = /^[,\.\;\:\?\!\)""“”\u2019‘`']+$/,
+  quotes = /^[\(""“”\u2019‘`']+$/,
+  squotes = /^[\u2019‘`']+$/,
+  apostrophes = /^[\u2019']+$/;
 
 let RiTa;
 
@@ -12,8 +18,7 @@ class Tokenizer {
   sentences(text, regex) {
     if (!text || !text.length) return [text];
 
-    const regexCompiled = /(\r?\n)+/g;
-    let clean = text.replace(regexCompiled, ' ')
+    let clean = text.replace(regexCompiledForsentences, ' ')
 
     let delim = '___';
     let re = new RegExp(delim, 'g');
@@ -92,11 +97,6 @@ class Tokenizer {
   untokenize(arr, delim) { // TODO: should be state machine
 
     delim = delim || ' ';
-
-    const punct = /^[,\.\;\:\?\!\)""“”\u2019‘`']+$/,
-      quotes = /^[\(""“”\u2019‘`']+$/,
-      squotes = /^[\u2019‘`']+$/,
-      apostrophes = /^[\u2019']+$/;
 
     let thisPunct, lastPunct, thisQuote, lastQuote, thisComma, isLast,
       lastComma, lastEndWithS, dbug = 0,

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -12,7 +12,8 @@ class Tokenizer {
   sentences(text, regex) {
     if (!text || !text.length) return [text];
 
-    let clean = text.replace(/(\r?\n)+/g, ' ')
+    const regexCompiled = /(\r?\n)+/g;
+    let clean = text.replace(regexCompiled, ' ')
 
     let delim = '___';
     let re = new RegExp(delim, 'g');
@@ -49,7 +50,7 @@ class Tokenizer {
     if (regex) return words.split(regex);
 
     words = words.trim(); // ???
-    words = words.replace(/([Ee])[.]([Gg])[.]/g, "_$1$2_"); // E.©G.
+    words = words.replace(/([Ee])[.]([Gg])[.]/g, "_$1$2_"); // E.G.
     words = words.replace(/([Ii])[.]([Ee])[.]/g, "_$1$2_"); // I.E.
 
     words = words.replace(/([\\?!\"\u201C\\.,;:@#$%&])/g, " $1 ");
@@ -92,12 +93,13 @@ class Tokenizer {
 
     delim = delim || ' ';
 
-    let thisPunct, lastPunct, thisQuote, lastQuote, thisComma, isLast,
-      lastComma, lastEndWithS, punct = /^[,\.\;\:\?\!\)""“”\u2019‘`']+$/,
-      dbug = 0,
+    const punct = /^[,\.\;\:\?\!\)""“”\u2019‘`']+$/,
       quotes = /^[\(""“”\u2019‘`']+$/,
       squotes = /^[\u2019‘`']+$/,
-      apostrophes = /^[\u2019']+$/,
+      apostrophes = /^[\u2019']+$/;
+
+    let thisPunct, lastPunct, thisQuote, lastQuote, thisComma, isLast,
+      lastComma, lastEndWithS, dbug = 0,
       afterQuote = false,
       withinQuote = arr.length && quotes.test(arr[0]),
       result = arr[0] || '',


### PR DESCRIPTION
pre compile regex as const in these files

`src/analyzer.js`

  `src/grammar.js`

  `src/lexicon.js` -> some very simple ones, like `/1/g`, are skipped

  `src/markov.js`

  `src/riscript.js` -> some very simple ones, like `/1/g`, are skipped

  `src/tokenizer` -> line 51 - 88 are not changed for readability of the code

refer to #14 